### PR TITLE
Possible solution for issue #30

### DIFF
--- a/pflockscreen/src/main/java/com/beautycoder/pflockscreen/PFFLockScreenConfiguration.java
+++ b/pflockscreen/src/main/java/com/beautycoder/pflockscreen/PFFLockScreenConfiguration.java
@@ -2,6 +2,9 @@ package com.beautycoder.pflockscreen;
 
 import android.content.Context;
 import androidx.annotation.IntDef;
+
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.view.View;
 
 import java.io.Serializable;
@@ -12,7 +15,52 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
 /**
  * Created by Aleksandr Nikiforov on 2018/02/14.
  */
-public class PFFLockScreenConfiguration implements Serializable {
+public class PFFLockScreenConfiguration implements Serializable, Parcelable {
+
+    protected PFFLockScreenConfiguration(Parcel in) {
+        mLeftButton = in.readString();
+        mNextButton = in.readString();
+        mUseFingerprint = in.readByte() != 0;
+        mAutoShowFingerprint = in.readByte() != 0;
+        mTitle = in.readString();
+        mMode = in.readInt();
+        mCodeLength = in.readInt();
+        mClearCodeOnError = in.readByte() != 0;
+        mErrorVibration = in.readByte() != 0;
+        mErrorAnimation = in.readByte() != 0;
+    }
+
+    public static final Creator<PFFLockScreenConfiguration> CREATOR =
+            new Creator<PFFLockScreenConfiguration>() {
+                @Override
+                public PFFLockScreenConfiguration createFromParcel(Parcel in) {
+                    return new PFFLockScreenConfiguration(in);
+                }
+
+                @Override
+                public PFFLockScreenConfiguration[] newArray(int size) {
+                    return new PFFLockScreenConfiguration[size];
+                }
+            };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(mLeftButton);
+        dest.writeString(mNextButton);
+        dest.writeByte((byte) (mUseFingerprint ? 1 : 0));
+        dest.writeByte((byte) (mAutoShowFingerprint ? 1 : 0));
+        dest.writeString(mTitle);
+        dest.writeInt(mMode);
+        dest.writeInt(mCodeLength);
+        dest.writeByte((byte) (mClearCodeOnError ? 1 : 0));
+        dest.writeByte((byte) (mErrorVibration ? 1 : 0));
+        dest.writeByte((byte) (mErrorAnimation ? 1 : 0));
+    }
 
     private String mLeftButton = "";
     private String mNextButton = "";

--- a/pflockscreen/src/main/java/com/beautycoder/pflockscreen/fragments/PFLockScreenFragment.java
+++ b/pflockscreen/src/main/java/com/beautycoder/pflockscreen/fragments/PFLockScreenFragment.java
@@ -63,6 +63,7 @@ public class PFLockScreenFragment extends Fragment {
     private View mRootView;
 
     private final PFPinCodeViewModel mPFPinCodeViewModel = new PFPinCodeViewModel();
+    private PFFingerprintAuthDialogFragment fragment;
 
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
@@ -81,6 +82,10 @@ public class PFLockScreenFragment extends Fragment {
             mConfiguration = (PFFLockScreenConfiguration) savedInstanceState.getSerializable(
                     INSTANCE_STATE_CONFIG
             );
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && isFingerprintApiAvailable(getActivity())) {
+            fragment = new PFFingerprintAuthDialogFragment();
         }
 
         mFingerprintButton = view.findViewById(R.id.button_finger_print);
@@ -117,6 +122,14 @@ public class PFLockScreenFragment extends Fragment {
             mOnFingerprintClickListener.onClick(mFingerprintButton);
         }
         super.onStart();
+    }
+
+    @Override
+    public void onPause() {
+        if (fragment != null) {
+            fragment.dismiss();
+        }
+        super.onPause();
     }
 
     public void setConfiguration(PFFLockScreenConfiguration configuration) {
@@ -222,8 +235,10 @@ public class PFLockScreenFragment extends Fragment {
                 return;
             }
 
-            final PFFingerprintAuthDialogFragment fragment
-                    = new PFFingerprintAuthDialogFragment();
+            if (fragment == null) {
+                return;
+            }
+
             fragment.show(getFragmentManager(), FINGERPRINT_DIALOG_FRAGMENT_TAG);
             fragment.setAuthListener(new PFFingerprintAuthListener() {
                 @Override


### PR DESCRIPTION
This is a possible solution for issue #30 
PFFLockScreenConfiguration implemented Serializable, but not Parcelable. The added functions in PFFLockScreenConfiguration are necessary to make the class serializable. The problem is, that now the PFLockScreenFragment is shown again and after resume the LockScreenFragment you will have two ore mor FingerprintFragments. To solve this problem, I dismiss the FingerprintFragment on onPause (if exists).